### PR TITLE
Update class.discussionpollsmodel.php to fix persistence of HTML characters

### DIFF
--- a/class.discussionpollsmodel.php
+++ b/class.discussionpollsmodel.php
@@ -191,7 +191,7 @@ class DiscussionPollsModel extends Gdn_Model {
 
       $this->SQL->Insert('DiscussionPolls', array(
           'DiscussionID' => $FormPostValues['DiscussionID'],
-          'Text' => $FormPostValues['DP_Title']));
+          'Text' => htmlspecialchars($FormPostValues['DP_Title'])));
 
       // Select the poll ID
       $this->SQL
@@ -206,7 +206,7 @@ class DiscussionPollsModel extends Gdn_Model {
         $this->SQL
                 ->Insert('DiscussionPollQuestions', array(
                     'PollID' => $PollID,
-                    'Text' => $Question)
+                    'Text' => htmlspecialchars($Question))
         );
       }
 
@@ -225,7 +225,7 @@ class DiscussionPollsModel extends Gdn_Model {
                   ->Insert('DiscussionPollQuestionOptions', array(
                       'QuestionID' => $QuestionID->QuestionID,
                       'PollID' => $PollID,
-                      'Text' => $Option)
+                      'Text' => htmlspecialchars($Option))
           );
         }
       }

--- a/class.discussionpollsmodel.php
+++ b/class.discussionpollsmodel.php
@@ -191,7 +191,7 @@ class DiscussionPollsModel extends Gdn_Model {
 
       $this->SQL->Insert('DiscussionPolls', array(
           'DiscussionID' => $FormPostValues['DiscussionID'],
-          'Text' => htmlspecialchars($FormPostValues['DP_Title'])));
+          'Text' => Gdn_Format::Text($FormPostValues['DP_Title'])));
 
       // Select the poll ID
       $this->SQL
@@ -206,7 +206,7 @@ class DiscussionPollsModel extends Gdn_Model {
         $this->SQL
                 ->Insert('DiscussionPollQuestions', array(
                     'PollID' => $PollID,
-                    'Text' => htmlspecialchars($Question))
+                    'Text' => Gdn_Format::Text($Question))
         );
       }
 
@@ -225,7 +225,7 @@ class DiscussionPollsModel extends Gdn_Model {
                   ->Insert('DiscussionPollQuestionOptions', array(
                       'QuestionID' => $QuestionID->QuestionID,
                       'PollID' => $PollID,
-                      'Text' => htmlspecialchars($Option))
+                      'Text' => Gdn_Format::Text($Option))
           );
         }
       }


### PR DESCRIPTION
Currently, you can save polls with HTML/Javascript in them which will be rendered to the screen when viewed.

This patch updates the model so that data persisted has been sanitized. Does not address previously saved polls with bad data in it. Not sure the best way to solve this.