### PR TITLE
Don't escape text in the model

### DIFF
--- a/class.discussionpollsmodel.php
+++ b/class.discussionpollsmodel.php
@@ -191,7 +191,7 @@ class DiscussionPollsModel extends Gdn_Model {
 
       $this->SQL->Insert('DiscussionPolls', array(
           'DiscussionID' => $FormPostValues['DiscussionID'],
-          'Text' => Gdn_Format::Text($FormPostValues['DP_Title'])));
+          'Text' => $FormPostValues['DP_Title']));
 
       // Select the poll ID
       $this->SQL
@@ -206,7 +206,7 @@ class DiscussionPollsModel extends Gdn_Model {
         $this->SQL
                 ->Insert('DiscussionPollQuestions', array(
                     'PollID' => $PollID,
-                    'Text' => Gdn_Format::Text($Question))
+                    'Text' => $Question)
         );
       }
 
@@ -225,7 +225,7 @@ class DiscussionPollsModel extends Gdn_Model {
                   ->Insert('DiscussionPollQuestionOptions', array(
                       'QuestionID' => $QuestionID->QuestionID,
                       'PollID' => $PollID,
-                      'Text' => Gdn_Format::Text($Option))
+                      'Text' => $Option)
           );
         }
       }

--- a/views/results.php
+++ b/views/results.php
@@ -6,7 +6,7 @@ function DPRenderResults($Poll) {
   echo '<div class="DP_ResultsForm">';
   
     if($TitleExists || $HideTitle) {
-      $TitleS = $Poll->Title;
+      $TitleS = Gdn_Format::Text($Poll->Title);
       if(trim($Poll->Title) != FALSE) {
         $TitleS .= '<hr />';
       }
@@ -34,14 +34,14 @@ function DPRenderResults($Poll) {
 
 function RenderQuestion($Question) {
   echo '<li class="DP_ResultQuestion">';
-  echo Wrap($Question->Title, 'span');
+  echo Wrap(Gdn_Format::Text($Question->Title), 'span');
   echo Wrap(sprintf(Plural($Question->CountResponses, '%s vote', '%s votes'), $Question->CountResponses), 'span', array('class' => 'Number DP_VoteCount'));
 
   // 'randomize' option bar colors
   $k = $Question->QuestionID % 10;
   echo '<ol class="DP_ResultOptions">';
   foreach($Question->Options as $Option) {
-    $String = Wrap($Option->Title, 'div');
+    $String = Wrap(Gdn_Format::Text($Option->Title), 'div');
     $Percentage = ($Question->CountResponses == 0) ? '0.00' : number_format(($Option->CountVotes / $Question->CountResponses * 100), 2);
     // Put text where it makes sense
     if($Percentage < 10) {

--- a/views/voting.php
+++ b/views/voting.php
@@ -3,7 +3,7 @@
 function DiscussionPollAnswerForm($PollForm, $Poll, $PartialAnswers) {
   echo '<div class="DP_AnswerForm">';
   if(GetValue('Title', $Poll) || C('Plugins.DiscussionPolls.DisablePollTitle', FALSE)) {
-    echo $Poll->Title;
+    echo Gdn_Format::Text($Poll->Title);
     if(trim($Poll->Title) != FALSE) {
       echo '<hr />';
     }
@@ -17,15 +17,15 @@ function DiscussionPollAnswerForm($PollForm, $Poll, $PartialAnswers) {
   foreach($Poll->Questions as $Question) {
     echo '<li class="DP_AnswerQuestion">';
     echo $PollForm->Hidden('DP_AnswerQuestions[]', array('value' => $Question->QuestionID));
-    echo Wrap($Question->Title, 'span');
+    echo Wrap(Gdn_Format::Text($Question->Title), 'span');
     echo '<ol class="DP_AnswerOptions">';
     foreach($Question->Options as $Option) {
       if(GetValue($Question->QuestionID, $PartialAnswers) == $Option->OptionID) {
         //fill in partial answer
-        echo Wrap($PollForm->Radio('DP_Answer' . $m, $Option->Title, array('Value' => $Option->OptionID, 'checked' => 'checked')), 'li');
+        echo Wrap($PollForm->Radio('DP_Answer' . $m, Gdn_Format::Text($Option->Title), array('Value' => $Option->OptionID, 'checked' => 'checked')), 'li');
       }
       else {
-        echo Wrap($PollForm->Radio('DP_Answer' . $m, $Option->Title, array('Value' => $Option->OptionID)), 'li');
+        echo Wrap($PollForm->Radio('DP_Answer' . $m, Gdn_Format::Text($Option->Title), array('Value' => $Option->OptionID)), 'li');
       }
     }
     echo '</ol>';


### PR DESCRIPTION
This makes escaping more consistent with the rest of vanilla (escaping
is done in the views, not the model).