### PR TITLE
Always return if DP_Attach field is not set

### DIFF
--- a/class.discussionpolls.plugin.php
+++ b/class.discussionpolls.plugin.php
@@ -416,8 +416,8 @@ class DiscussionPollsPlugin extends Gdn_Plugin {
       if($DPModel->Exists($DiscussionID)) {
         Gdn::Controller()->InformMessage(T('Plugins.DiscussionPolls.PollRemoved', 'The attached poll has been removed'));
         $DPModel->DeleteByDiscussionID($DiscussionID);
-        return FALSE;
       }
+      return FALSE;
     }
 
     if($DPModel->Exists($DiscussionID)) {


### PR DESCRIPTION
This fixes an error, where an empty poll is saved when splitting a discussion if "Disable poll titles" is enabled.