### PR TITLE
Fix checkbox not being ticked properly

### DIFF
--- a/js/admin.discussionpolls.js
+++ b/js/admin.discussionpolls.js
@@ -23,7 +23,7 @@ jQuery(document).ready(function($) {
   var AddQString = $('#DP_NextQuestion').text();
 
   // If there is input in the first question textbox onload, this is an existing poll
-  if ($('#DP_Questions0').val()) {
+  if ($('#DP_Questions01').val()) {
     ExistingPoll = true;
     // Hide the extra questions and make the buttons make sense
     if ($('fieldset.DP_Question').length > 1) {


### PR DESCRIPTION
In newer vanilla versions the first field has the ID `#DP_Questions01` which leads to users accidentally deleting polls when editing discussions as the checkbox to attach a poll is always unchecked.