### PR TITLE
2.6 compatibility

### DIFF
--- a/addon.json
+++ b/addon.json
@@ -1,0 +1,24 @@
+{
+    "name": "Discussion Polls",
+    "description": "A plugin that allows creating polls that attach to a discussion. Respects permissions.",
+    "version": "1.3.6",
+    "registerPermissions": [
+        "Plugins.DiscussionPolls.Add",
+        "Plugins.DiscussionPolls.View",
+        "Plugins.DiscussionPolls.Vote",
+        "Plugins.DiscussionPolls.Manage"
+    ],
+    "mobileFriendly": true,
+    "settingsUrl": "/dashboard/settings/discussionpolls",
+    "settingsPermission": "Garden.Settings.Manage",
+    "license": "GPLv3",
+    "key": "discussionpolls",
+    "type": "addon",
+    "authors": [
+        {
+            "name": "Zachary Doll",
+            "email": "hgtonight@daklutz.com",
+            "homepage": "http://www.daklutz.com"
+        }
+    ]
+}

--- a/class.discussionpolls.plugin.php
+++ b/class.discussionpolls.plugin.php
@@ -148,7 +148,7 @@ class DiscussionPollsPlugin extends Gdn_Plugin {
    */
   public function Controller_Results($Sender) {
     $DPModel = new DiscussionPollsModel();
-    $Poll = $DPModel->Get($Sender->RequestArgs[1]);
+    $Poll = $DPModel->GetID($Sender->RequestArgs[1]);
 
     $PollResults = $this->_RenderResults($Poll, FALSE);
     if($Sender->DeliveryType() == DELIVERY_TYPE_VIEW) {
@@ -172,7 +172,7 @@ class DiscussionPollsPlugin extends Gdn_Plugin {
     $DPModel = new DiscussionPollsModel();
     $DiscussionModel = new DiscussionModel();
 
-    $Poll = $DPModel->Get($Sender->RequestArgs[1]);
+    $Poll = $DPModel->GetID($Sender->RequestArgs[1]);
 
     $Discussion = $DiscussionModel->GetID($Poll->DiscussionID);
 
@@ -180,7 +180,7 @@ class DiscussionPollsPlugin extends Gdn_Plugin {
 
     if($Session->CheckPermission('Plugins.DiscussionPolls.Manage') || $PollOwnerID == $Session->UserID) {
       $DPModel = new DiscussionPollsModel();
-      $DPModel->Delete($Sender->RequestArgs[1]);
+      $DPModel->DeleteID($Sender->RequestArgs[1]);
 
       $Result = 'Removed poll with id ' . $Sender->RequestArgs[1];
       if($Sender->DeliveryType() == DELIVERY_TYPE_VIEW) {
@@ -650,7 +650,7 @@ class DiscussionPollsPlugin extends Gdn_Plugin {
       $View = $ThemeViewLoc . DS . $View . '.php';
     }
     else {
-      $View = $this->GetView($View . '.php');
+      $View = Gdn::controller()->fetchViewLocation($View, '', 'plugins/DiscussionPolls');
     }
 
     return $View;

--- a/class.discussionpollsmodel.php
+++ b/class.discussionpollsmodel.php
@@ -80,7 +80,7 @@ class DiscussionPollsModel extends Gdn_Model {
    * @param int $PollID
    * @return stdClass Poll object
    */
-  public function Get($PollID) {
+  public function GetID($PollID, $DatasetType = false, $Options = []) {
     //check for cached result
     $Data = GetValueR('Get.' . $PollID, self::$Cache);
 
@@ -176,14 +176,14 @@ class DiscussionPollsModel extends Gdn_Model {
         $PollID = NULL;
       }
     }
-    return $this->Get($PollID);
+    return $this->GetID($PollID);
   }
 
   /**
    * Saves the poll object
    * @param array $FormPostValues
    */
-  public function Save($FormPostValues) {
+  public function Save($FormPostValues, $Settings = false) {
     //paranoid
     self::PurgeCache();
     try {
@@ -420,7 +420,7 @@ class DiscussionPollsModel extends Gdn_Model {
         $Answered[$QuestionID] = $FormPostValues[$MemberKey];
       }
     }
-    $Poll = $this->Get($FormPostValues['PollID']);
+    $Poll = $this->GetID($FormPostValues['PollID']);
 
     return count((array) $Poll->Questions) == count($Answered);
   }
@@ -429,7 +429,7 @@ class DiscussionPollsModel extends Gdn_Model {
    * Removes all data associated with the poll id
    * @param int $PollID
    */
-  public function Delete($PollID) {
+  public function DeleteID($PollID, $Options = []) {
     try {
       $this->Database->BeginTransaction();
       $this->SQL->Delete('DiscussionPolls', array('PollID' => $PollID));
@@ -464,7 +464,7 @@ class DiscussionPollsModel extends Gdn_Model {
       $Data = $this->SQL->Get()->FirstRow();
       $PollID = $Data->PollID;
 
-      return $this->Delete($PollID);
+      return $this->DeleteID($PollID);
     }
   }
 


### PR DESCRIPTION
* Model notices fixed by renaming `Get` to `GetID` and  `Delete` to `DeleteID` (since `Get` and `Delete` operate on `WHERE` arrays in core).
* Replaced deprecated `GetView`
* added addon.json file